### PR TITLE
fix(ci): auth.setup.js fail-fast + require NNTN_USR · restore CI baseline

### DIFF
--- a/.github/workflows/qa-playwright.yml
+++ b/.github/workflows/qa-playwright.yml
@@ -31,6 +31,7 @@ jobs:
 
       - name: Run Playwright tests
         env:
+          NNTN_USR: ${{ secrets.NNTN_USR }}
           NNTN_PWD: ${{ secrets.NNTN_PWD }}
           CI: true
         run: npx playwright test

--- a/tests/auth.setup.js
+++ b/tests/auth.setup.js
@@ -5,19 +5,40 @@ const path = require('path');
 const authFile = path.join(__dirname, '..', 'playwright', '.auth', 'user.json');
 
 setup('authenticate', async ({ page }) => {
-  await page.goto('login.html');
+  const usr = process.env.NNTN_USR;
   const pwd = process.env.NNTN_PWD;
+  if (!usr) {
+    throw new Error('NNTN_USR env var is required — use full email e.g. platformci@staffnntn.co (set locally or via GitHub Secret)');
+  }
   if (!pwd) {
     throw new Error('NNTN_PWD env var is required (set locally or via GitHub Secret)');
   }
-  await page.locator('#usr').fill(process.env.NNTN_USR || 'ci');
+
+  // Capture the login response so we can surface the real auth error instead of
+  // failing 30s later on waitForURL with no useful context.
+  let loginResponse = null;
+  page.on('response', (r) => {
+    if (r.url().includes('/auth/v1/token')) loginResponse = r;
+  });
+
+  await page.goto('login.html');
+  await page.locator('#usr').fill(usr);
   await page.locator('#pwd').fill(pwd);
   await page.click('#btn');
 
-  // รอ redirect ออกจาก login.html (→ index.html)
-  await page.waitForURL(url => !url.pathname.endsWith('login.html'), { timeout: 30_000 });
+  try {
+    await page.waitForURL((url) => !url.pathname.endsWith('login.html'), { timeout: 15_000 });
+  } catch (e) {
+    if (loginResponse && !loginResponse.ok()) {
+      const body = await loginResponse.text().catch(() => '<unreadable>');
+      throw new Error(
+        `Login failed: ${loginResponse.status()} ${loginResponse.statusText()} · ${body.slice(0, 200)} · ` +
+        `usr "${usr}" — verify GitHub Secret NNTN_USR is full email (login.html appends @nntn.internal if no @ in input)`
+      );
+    }
+    throw e;
+  }
 
-  // verify token ถูก set
   const token = await page.evaluate(() => localStorage.getItem('nntn_sb_token'));
   expect(token).toBeTruthy();
 


### PR DESCRIPTION
## Summary
- Require `NNTN_USR` env var (no silent fallback to 'ci' which was breaking CI for unknown days)
- Capture `/auth/v1/token` response · surface real status + body if `waitForURL` times out (saves 30s of mystery + tells you exactly what's wrong)
- Drop wait timeout 30s → 15s (login is sub-second or it's misconfigured)
- Companion: GitHub secret `NNTN_USR` updated to `platformci@staffnntn.co` (verified working via direct API call)

## Root cause
Old code: `process.env.NNTN_USR || 'ci'`. Secret was set but value lacked domain → login.html `buildEmail` appended `@nntn.internal` → `ci@nntn.internal` → invalid_credentials → `waitForURL` polled for 30s with zero diagnostic info → CI failed.

Verified locally:
```
ci@nntn.internal             → 400 invalid_credentials
platformci@staffnntn.co      → 200 access_token=...
```

## Test plan
- [ ] CI on this PR `qa-playwright` → all 89 tests pass (auth.setup.js no longer times out)
- [ ] PR #3 (Semgrep) Code Scanning tab populated by next scan after merge
- [ ] If somehow still broken: error message now includes status + body so root cause is obvious in CI log