### PR TITLE
fix(ci): semgrep ERROR-only gate now actually filters (--severity is scan-only)

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -25,19 +25,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0   # full history so diff-aware scan can resolve base ref
+          fetch-depth: 0
+
+      - name: Mark workspace safe (container UID mismatch with checkout owner)
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       # Phase A · ERROR-only gate. Legacy code has many WARNING findings
-      # (innerHTML/onclick patterns: hub-delivery 84 · po-receive 29 · stock-dispense 26 ·
-      # stock-report 24 · sop-review 23 · admin-items 21). Promote to ERROR+WARNING
-      # in Phase B once cleanup is done.
+      # (innerHTML/onclick patterns). Promote to ERROR+WARNING in Phase B
+      # once cleanup is done.
+      #
+      # `--severity` is a `semgrep scan` flag (not `semgrep ci`). Use `scan`
+      # so the gate actually filters severity. `--error` exits non-zero on findings.
       - name: Run Semgrep (ERROR-only gate · SARIF upload all severities)
         run: |
-          semgrep ci \
+          semgrep scan \
             --config=p/security-audit \
             --config=p/owasp-top-ten \
             --config=p/javascript \
             --severity=ERROR \
+            --error \
             --sarif --output=semgrep.sarif \
             --metrics=off
         env:


### PR DESCRIPTION
## Summary
- `semgrep ci` rejects `--severity` → workflow has been silently FAIL since adoption (PR#3 03/05)
- Switch to `semgrep scan --severity=ERROR --error` so the gate actually works
- Add `safe.directory` git config to silence container UID/checkout-owner mismatch warning

## Root cause
`--severity` is a `semgrep scan` flag · using it with `semgrep ci` → `unknown option --severity` → exit 2 → all 7 runs since adoption red. Cascading: missing `semgrep.sarif` (never produced) + git 'dubious ownership' warning.

## Why this matters
SAST gate has been false-security: zero CVEs detected since adoption because CLI never started scanning. Stock supply-chain protection effectively off.

## Test plan
- [ ] CI run on this PR completes (no `--severity` error)
- [ ] SARIF uploaded to Code Scanning
- [ ] **Post-merge verify on main green** (lesson: TUNE→GO needs post-merge run check)

## References
- Reported by: nntn-coo 2026-05-06 08:56 (discovered while verifying PR#8)
- Original adoption: PR#3 03/05 (Kati TUNE→GO without post-merge verify · noted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)