### PR TITLE
feat(ci): QA Gate workflow · require 'qa-pass' label before merge

### DIFF
--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -1,0 +1,32 @@
+name: QA Gate
+
+# Mechanical guard · PR ต้องมี label 'qa-pass' จาก Kati ก่อน merge
+# Triggered on label add/remove + PR sync · re-runs ทุกครั้ง label เปลี่ยน
+# Reference: STL escalation ladder N=3 (3/7 PR bypass Kati gate · trust corrosion)
+# Approved by TINE 2026-05-06 19:28
+
+on:
+  pull_request_target:
+    types: [opened, reopened, labeled, unlabeled, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  require-qa-pass:
+    name: Require qa-pass label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify qa-pass label present
+        env:
+          LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          echo "PR #${PR_NUMBER} labels: ${LABELS_JSON}"
+          if echo "${LABELS_JSON}" | jq -e 'index("qa-pass")' >/dev/null; then
+            echo "✅ qa-pass label present · gate open"
+            exit 0
+          fi
+          echo "::error::PR missing qa-pass label · Kati must verify + post 'qa-pass' label before merge"
+          exit 1


### PR DESCRIPTION
## Why
3/7 PR last 7d bypass Kati QA gate (Kati audit · trust corrosion). STL escalation ladder N=3 → mechanical pierce. TINE approved 19:28.

## What
Add `.github/workflows/qa-gate.yml` ที่ fail ถ้า PR ไม่มี label `qa-pass`.

- Triggers: `pull_request_target` (opened, reopened, labeled, unlabeled, synchronize) · re-runs ทุกครั้ง label เปลี่ยน
- Pure label check (`jq` over `github.event.pull_request.labels.*.name`) · ไม่ checkout code · ไม่มี third-party action → safe under pull_request_target
- Failure msg: `PR missing qa-pass label · Kati must verify + post 'qa-pass' label before merge`

## How Kati ติด label
หลัง QA verify pass · run:
```bash
gh pr edit <PR#> --add-label qa-pass
# หรือ Dashboard: PR → Labels → qa-pass
```
Workflow re-runs ทันที · status check flip green · merge ปลดล็อก

## Post-merge follow-ups (Platform)
- [ ] GitHub branch protection: main require status check `Require qa-pass label`
- [ ] Branch protection: require ≥1 approving review
- [ ] Discord [DEPLOY][DOC] post #platform
- [ ] Create label `qa-pass` ใน repo (ถ้ายังไม่มี · `gh label create`)

## Test plan
- [ ] CI runs on this PR · expect FAIL (no qa-pass label) — proves gate works
- [ ] Kati add `qa-pass` label · CI re-runs · expect PASS
- [ ] Kati / TINE merge

## Reference
- STL N=3 escalation ladder
- Kati audit 06/05: 3/7 PR bypass
- TINE approve 19:28

🤖 Generated with [Claude Code](https://claude.com/claude-code)